### PR TITLE
feat: add personal agenda

### DIFF
--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -12,160 +12,145 @@ import Seo from "../components/seo";
 import Hero from "../components/hero";
 import { icon } from "@fortawesome/fontawesome-svg-core/import.macro";
 
-class Talks extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: props.scheduleData,
-      required: {
-        show: false,
-        title: "Titolo",
-        description: "Descrizione",
-        author: "Autore",
-        room: "Aula",
-        duration: "Durata",
-        slides: "",
-        video: "",
-      },
-    };
-    this.replaceModalItem = this.replaceModalItem.bind(this);
-  }
+const Talks = ({ scheduleData }) => {
+  const [data, setData] = useState(scheduleData);
+  const [modalData, setModalData] = useState({
+    show: false,
+    title: "Titolo",
+    description: "Descrizione",
+    author: "Autore",
+    room: "Aula",
+    duration: "Durata",
+    slides: "",
+    video: "",
+  });
 
-  replaceModalItem(item) {
-    this.setState({
-      required: {
-        ...item,
-        show: !this.state.required.show,
-      },
-    });
-  }
+  const replaceModalItem = (item) => {
+    setModalData((current) => ({
+      ...item,
+      show: !current.show,
+    }));
+  };
 
-  render() {
-    let modalData = this.state.required;
-    return (
-      <>
-        <Modal
-          show={modalData.show}
-          onHide={() => {
-            this.setState({
-              required: {
-                ...modalData,
-                show: false,
-              },
-            });
-          }}
-          size='lg'
-          aria-labelledby='contained-modal-title-vcenter'
-          centered
-        >
-          <Modal.Header closeButton>
-            <Modal.Title id='contained-modal-title-vcenter'>
-              {modalData.title}
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <p>{modalData.description}</p>
-            <br />
-            <h6>{modalData.author}</h6>
-            <Row>
-              <Col>{modalData.duration && "Durata: " + modalData.duration}</Col>
-              <Col className='text-end'>
-                {modalData.room && "Aula: " + modalData.room}
-              </Col>
-            </Row>
-          </Modal.Body>
-          <Modal.Footer>
-            {!(modalData.video === "" || modalData.video === null) && (
-              <Button target='_blank' href={modalData.video} variant='warning'>
-                <FontAwesomeIcon
-                  icon={icon({
-                    name: "video",
-                    family: "classic",
-                    style: "solid",
-                  })}
-                />{" "}
-                Video
-              </Button>
-            )}
-            {!(modalData.slides === "" || modalData.slides === null) && (
-              <Button target='_blank' href={modalData.slides} variant='warning'>
-                <FontAwesomeIcon
-                  icon={icon({
-                    name: "download",
-                    family: "classic",
-                    style: "solid",
-                  })}
-                />{" "}
-                Slides
-              </Button>
-            )}
-            <Button
-              variant='warning'
-              onClick={() => {
-                this.setState({
-                  required: {
-                    ...modalData,
-                    show: false,
-                  },
-                });
-              }}
-            >
-              Chiudi
+  return (
+    <>
+      <Modal
+        show={modalData.show}
+        onHide={() => {
+          setModalData((current) => ({
+            ...current,
+            show: false,
+          }));
+        }}
+        size='lg'
+        aria-labelledby='contained-modal-title-vcenter'
+        centered
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id='contained-modal-title-vcenter'>
+            {modalData.title}
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>{modalData.description}</p>
+          <br />
+          <h6>{modalData.author}</h6>
+          <Row>
+            <Col>{modalData.duration && "Durata: " + modalData.duration}</Col>
+            <Col className='text-end'>
+              {modalData.room && "Aula: " + modalData.room}
+            </Col>
+          </Row>
+        </Modal.Body>
+        <Modal.Footer>
+          {!(modalData.video === "" || modalData.video === null) && (
+            <Button target='_blank' href={modalData.video} variant='warning'>
+              <FontAwesomeIcon
+                icon={icon({
+                  name: "video",
+                  family: "classic",
+                  style: "solid",
+                })}
+              />{" "}
+              Video
             </Button>
-          </Modal.Footer>
-        </Modal>
-        {this.state.data.map((i, k) => {
-          return (
-            <Row key={k} className='pb-4'>
-              <Col lg={1} md={12} className='pb-4 mr-2'>
-                <h5 className='schedule-time'>{i.time}</h5>
-              </Col>
-              {i.talks.map((t, u) => {
-                return (
-                  <Col key={u} sm={12} md className='pb-4'>
-                    <div
-                      onKeyPress={() => this.replaceModalItem(t)}
-                      onClick={() => this.replaceModalItem(t)}
-                      className='event border rounded h-100 d-flex flex-column'
-                      style={{
-                        padding: "1rem",
-                        cursor: "pointer",
-                      }}
-                    >
-                      <Row>
-                        <Col>
-                          <h5>{t.title}</h5>
-                        </Col>
-                      </Row>
-                      <Row className='mt-2'>
-                        <Col>
-                          <h6>{t.author}</h6>
-                        </Col>
-                      </Row>
-                      <Row className='flex-grow-1 mt-3 align-items-end'>
-                        <Col className='text-start'>{t.duration}</Col>
-                        <Col className='text-center'>{t.room}</Col>
-                        <Col className='text-end'>
-                          <FontAwesomeIcon
-                            icon={icon({
-                              name: "info-circle",
-                              family: "classic",
-                              style: "solid",
-                            })}
-                          />
-                        </Col>
-                      </Row>
-                    </div>
-                  </Col>
-                );
-              })}
-            </Row>
-          );
-        })}
-      </>
-    );
-  }
-}
+          )}
+          {!(modalData.slides === "" || modalData.slides === null) && (
+            <Button target='_blank' href={modalData.slides} variant='warning'>
+              <FontAwesomeIcon
+                icon={icon({
+                  name: "download",
+                  family: "classic",
+                  style: "solid",
+                })}
+              />{" "}
+              Slides
+            </Button>
+          )}
+          <Button
+            variant='warning'
+            onClick={() => {
+              setModalData((current) => ({
+                ...current,
+                show: false,
+              }));
+            }}
+          >
+            Chiudi
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      {data.map((i, k) => {
+        return (
+          <Row key={k} className='pb-4'>
+            <Col lg={1} md={12} className='pb-4 mr-2'>
+              <h5 className='schedule-time'>{i.time}</h5>
+            </Col>
+            {i.talks.map((t, u) => {
+              return (
+                <Col key={u} sm={12} md className='pb-4'>
+                  <div
+                    onKeyPress={() => replaceModalItem(t)}
+                    onClick={() => replaceModalItem(t)}
+                    className='event border rounded h-100 d-flex flex-column'
+                    style={{
+                      padding: "1rem",
+                      cursor: "pointer",
+                    }}
+                  >
+                    <Row>
+                      <Col>
+                        <h5>{t.title}</h5>
+                      </Col>
+                    </Row>
+                    <Row className='mt-2'>
+                      <Col>
+                        <h6>{t.author}</h6>
+                      </Col>
+                    </Row>
+                    <Row className='flex-grow-1 mt-3 align-items-end'>
+                      <Col className='text-start'>{t.duration}</Col>
+                      <Col className='text-center'>{t.room}</Col>
+                      <Col className='text-end'>
+                        <FontAwesomeIcon
+                          icon={icon({
+                            name: "info-circle",
+                            family: "classic",
+                            style: "solid",
+                          })}
+                        />
+                      </Col>
+                    </Row>
+                  </div>
+                </Col>
+              );
+            })}
+          </Row>
+        );
+      })}
+    </>
+  );
+};
 
 const activeEnv =
   process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || "development";

--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -32,6 +32,30 @@ const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
     }));
   };
 
+  const handleStarClick = (title, clickEvent) => {
+    clickEvent.stopPropagation();
+    toggleTalkStar(title);
+  };
+
+  const StarToggle = ({ title }) => (
+    <FontAwesomeIcon
+      icon={
+        starredTalksForYear?.includes(title)
+          ? icon({
+              name: "star",
+              family: "classic",
+              style: "solid",
+            })
+          : icon({
+              name: "star",
+              family: "classic",
+              style: "regular",
+            })
+      }
+      onClick={(e) => handleStarClick(title, e)}
+    />
+  );
+
   return (
     <>
       <Modal
@@ -62,42 +86,57 @@ const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
             </Col>
           </Row>
         </Modal.Body>
-        <Modal.Footer>
-          {!(modalData.video === "" || modalData.video === null) && (
-            <Button target='_blank' href={modalData.video} variant='warning'>
-              <FontAwesomeIcon
-                icon={icon({
-                  name: "video",
-                  family: "classic",
-                  style: "solid",
-                })}
-              />{" "}
-              Video
+        <Modal.Footer className='justify-content-between'>
+          <div className='d-flex flex-start'>
+            <Button
+              variant='warning'
+              onClick={(e) => handleStarClick(modalData.title, e)}
+              className='d-flex gap-1 align-items-center'
+            >
+              <StarToggle title={modalData.title} />
+              {starredTalksForYear?.includes(modalData.title)
+                ? "Rimuovi da"
+                : "Aggiungi ad"}{" "}
+              agenda personale
             </Button>
-          )}
-          {!(modalData.slides === "" || modalData.slides === null) && (
-            <Button target='_blank' href={modalData.slides} variant='warning'>
-              <FontAwesomeIcon
-                icon={icon({
-                  name: "download",
-                  family: "classic",
-                  style: "solid",
-                })}
-              />{" "}
-              Slides
+          </div>
+          <div className='d-flex flex-end'>
+            {!(modalData.video === "" || modalData.video === null) && (
+              <Button target='_blank' href={modalData.video} variant='warning'>
+                <FontAwesomeIcon
+                  icon={icon({
+                    name: "video",
+                    family: "classic",
+                    style: "solid",
+                  })}
+                />{" "}
+                Video
+              </Button>
+            )}
+            {!(modalData.slides === "" || modalData.slides === null) && (
+              <Button target='_blank' href={modalData.slides} variant='warning'>
+                <FontAwesomeIcon
+                  icon={icon({
+                    name: "download",
+                    family: "classic",
+                    style: "solid",
+                  })}
+                />{" "}
+                Slides
+              </Button>
+            )}
+            <Button
+              variant='warning'
+              onClick={() => {
+                setModalData((current) => ({
+                  ...current,
+                  show: false,
+                }));
+              }}
+            >
+              Chiudi
             </Button>
-          )}
-          <Button
-            variant='warning'
-            onClick={() => {
-              setModalData((current) => ({
-                ...current,
-                show: false,
-              }));
-            }}
-          >
-            Chiudi
-          </Button>
+          </div>
         </Modal.Footer>
       </Modal>
       {data.map((i, k) => {
@@ -132,25 +171,7 @@ const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
                       <Col className='text-start'>{t.duration}</Col>
                       <Col className='text-center'>{t.room}</Col>
                       <Col className='text-end d-flex gap-1 justify-content-end'>
-                        <FontAwesomeIcon
-                          icon={
-                            starredTalksForYear?.includes(t.title)
-                              ? icon({
-                                  name: "star",
-                                  family: "classic",
-                                  style: "solid",
-                                })
-                              : icon({
-                                  name: "star",
-                                  family: "classic",
-                                  style: "regular",
-                                })
-                          }
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            toggleTalkStar(t.title);
-                          }}
-                        />
+                        <StarToggle title={t.title} />
                         <FontAwesomeIcon
                           icon={icon({
                             name: "info-circle",

--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -181,7 +181,7 @@ const Talks = ({
                       <Col className='align-bottom text-center'>{t.room}</Col>
                       <Col className='d-flex gap-1 justify-content-end'>
                         <Button variant='warning'
-                          onClick={(e) => handleStarClick(modalData.title, e)}>
+                          onClick={(e) => handleStarClick(t.title, e)}>
                             <StarToggle title={t.title} />
                             </Button>
                       </Col>

--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -47,15 +47,15 @@ const Talks = ({
       icon={
         starredTalksForYear?.includes(title)
           ? icon({
-              name: "star",
-              family: "classic",
-              style: "solid",
-            })
+            name: "star",
+            family: "classic",
+            style: "solid",
+          })
           : icon({
-              name: "star",
-              family: "classic",
-              style: "regular",
-            })
+            name: "star",
+            family: "classic",
+            style: "regular",
+          })
       }
       onClick={(e) => handleStarClick(title, e)}
     />
@@ -151,7 +151,7 @@ const Talks = ({
               <h5 className='schedule-time'>{i.time}</h5>
             </Col>
             {i.talks.map((t, u) => {
-              console.log(showStarred);
+              if ("development" === activeEnv) console.log(showStarred);
               return !showStarred || starredTalksForYear?.includes(t.title) ? (
                 <Col key={u} sm={12} md className='pb-4'>
                   <div
@@ -173,18 +173,17 @@ const Talks = ({
                         <h6>{t.author}</h6>
                       </Col>
                     </Row>
-                    <Row className='flex-grow-1 mt-3 align-items-end'>
-                      <Col className='text-start'>{t.duration}</Col>
-                      <Col className='text-center'>{t.room}</Col>
-                      <Col className='text-end d-flex gap-1 justify-content-end'>
-                        <StarToggle title={t.title} />
-                        <FontAwesomeIcon
-                          icon={icon({
-                            name: "info-circle",
-                            family: "classic",
-                            style: "solid",
-                          })}
-                        />
+                    <Row className='d-flex flex-grow-1' />
+                    <Row className='mt-3 align-items-center'>
+                      <Col className='align-bottom text-start'>
+                        {t.duration}
+                      </Col>
+                      <Col className='align-bottom text-center'>{t.room}</Col>
+                      <Col className='d-flex gap-1 justify-content-end'>
+                        <Button variant='warning'
+                          onClick={(e) => handleStarClick(modalData.title, e)}>
+                            <StarToggle title={t.title} />
+                            </Button>
                       </Col>
                     </Row>
                   </div>
@@ -252,7 +251,7 @@ const Page = ({ data }) => {
                 Programma della giornata
               </h2>
 
-              <div className='d-flex flex-row gap-3'>
+              <div className='d-flex flex-row gap-3 d-print-none'>
                 <Button
                   variant='warning'
                   onClick={() => setShowStarred((curr) => !curr)}
@@ -274,7 +273,7 @@ const Page = ({ data }) => {
                           onClick={() => {
                             navigate(
                               typeof window !== "undefined" &&
-                                window.location.pathname + "?year=" + s.year
+                              window.location.pathname + "?year=" + s.year
                             );
                             setSchedData(allSchedules[i]);
                           }}

--- a/src/pages/schedule.jsx
+++ b/src/pages/schedule.jsx
@@ -12,7 +12,12 @@ import Seo from "../components/seo";
 import Hero from "../components/hero";
 import { icon } from "@fortawesome/fontawesome-svg-core/import.macro";
 
-const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
+const Talks = ({
+  scheduleData,
+  showStarred,
+  starredTalksForYear,
+  toggleTalkStar,
+}) => {
   const [data, setData] = useState(scheduleData);
   const [modalData, setModalData] = useState({
     show: false,
@@ -146,7 +151,8 @@ const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
               <h5 className='schedule-time'>{i.time}</h5>
             </Col>
             {i.talks.map((t, u) => {
-              return (
+              console.log(showStarred);
+              return !showStarred || starredTalksForYear?.includes(t.title) ? (
                 <Col key={u} sm={12} md className='pb-4'>
                   <div
                     onKeyPress={() => replaceModalItem(t)}
@@ -183,7 +189,7 @@ const Talks = ({ scheduleData, starredTalksForYear, toggleTalkStar }) => {
                     </Row>
                   </div>
                 </Col>
-              );
+              ) : undefined;
             })}
           </Row>
         );
@@ -199,6 +205,7 @@ const Page = ({ data }) => {
   const allSchedules = data.allSchedulesYaml.nodes;
   const [schedData, setSchedData] = useState(allSchedules[0]);
   const [starredTalks, setStarredTalks] = useState({});
+  const [showStarred, setShowStarred] = useState(false);
 
   const params = new URLSearchParams(
     typeof window !== "undefined" && window.location.search
@@ -244,42 +251,51 @@ const Page = ({ data }) => {
               <h2 className='text-md-left text-center'>
                 Programma della giornata
               </h2>
-              <hr />
-              {data.site.siteMetadata.switches.year_switcher ? (
-                <Dropdown className='d-block d-md-inline d-print-none'>
-                  <Dropdown.Toggle
-                    className='w-100 w-sm-auto'
-                    variant='warning'
-                  >
+
+              <div className='d-flex flex-row gap-3'>
+                <Button
+                  variant='warning'
+                  onClick={() => setShowStarred((curr) => !curr)}
+                >
+                  {showStarred ? "Tutte le talk" : "Agenda personale"}
+                </Button>
+                {data.site.siteMetadata.switches.year_switcher ? (
+                  <Dropdown className='d-block d-md-inline d-print-none'>
+                    <Dropdown.Toggle
+                      className='w-100 w-sm-auto'
+                      variant='warning'
+                    >
+                      Anno {schedData?.year}
+                    </Dropdown.Toggle>
+                    <Dropdown.Menu>
+                      {allSchedules.map((s, i) => (
+                        <Dropdown.Item
+                          key={i}
+                          onClick={() => {
+                            navigate(
+                              typeof window !== "undefined" &&
+                                window.location.pathname + "?year=" + s.year
+                            );
+                            setSchedData(allSchedules[i]);
+                          }}
+                        >
+                          {s.year}
+                        </Dropdown.Item>
+                      ))}
+                    </Dropdown.Menu>
+                  </Dropdown>
+                ) : (
+                  <small className='d-none d-sm-block'>
                     Anno {schedData?.year}
-                  </Dropdown.Toggle>
-                  <Dropdown.Menu>
-                    {allSchedules.map((s, i) => (
-                      <Dropdown.Item
-                        key={i}
-                        onClick={() => {
-                          navigate(
-                            typeof window !== "undefined" &&
-                              window.location.pathname + "?year=" + s.year
-                          );
-                          setSchedData(allSchedules[i]);
-                        }}
-                      >
-                        {s.year}
-                      </Dropdown.Item>
-                    ))}
-                  </Dropdown.Menu>
-                </Dropdown>
-              ) : (
-                <small className='d-none d-sm-block'>
-                  Anno {schedData?.year}
-                </small>
-              )}
+                  </small>
+                )}
+              </div>
             </div>
 
             {schedData?.schedule.length ? (
               <Talks
                 scheduleData={schedData?.schedule}
+                showStarred={showStarred}
                 starredTalksForYear={starredTalks[schedData?.year]}
                 toggleTalkStar={(title) => {
                   setStarredTalks((current) => {


### PR DESCRIPTION
This PR adds a way to star talks, so that each user can build their own personal agenda.
The preference is saved in the user's local storage.
There is also a way for the user to filter the schedule, showing only the talks they starred.

There is for sure room for improvement if we want to get fancy with animations and stuff, but I think this is a pretty good starting point 🍀 

Closes #34 